### PR TITLE
Fixed the ValueError raised by numpy when using numpy.nan as the threshold kwarg of numpy.set_printoptions

### DIFF
--- a/ooktools/commands/information.py
+++ b/ooktools/commands/information.py
@@ -24,13 +24,15 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from sys import maxsize
+
 import click
 import numpy
 
 from ..utilities import cleanup_wave_data
 
 # Let numpy print full arrays
-numpy.set_printoptions(threshold=numpy.nan)
+numpy.set_printoptions(threshold=maxsize)
 
 
 def get_wave_info(wave_file):


### PR DESCRIPTION
Fixed the issue discussed [here](https://github.com/leonjza/ooktools/issues/1) where `numpy` would complain about `numpy.set_printoptions`' threshold kwarg being `numpy.nan`.

The fix was suggested in [one of numpy's issues](https://github.com/numpy/numpy/issues/12987#issuecomment-464893305) where one of it's maintainers stated that using `threshold=numpy.nan` was never supposed to be supported. The suggested fix is to replace `numpy.nan` with `sys.maxsize` which is what has been done (and tested) here.